### PR TITLE
Handle non-existing hostnames

### DIFF
--- a/DVS.psm1
+++ b/DVS.psm1
@@ -351,12 +351,7 @@ function Get-GetHostByName {
     if($Hostname -eq $env:COMPUTERNAME) {
         return "127.0.0.1"
     }
-    try {
-        return [System.Net.Dns]::GetHostByName($Hostname).AddressList[0].IPAddressToString
-    } catch {
-        Write-Log -Level ERROR -Message "$Hostname $_" -forceVerbose
-        return ""
-    }
+    return [System.Net.Dns]::GetHostByName($Hostname).AddressList[0].IPAddressToString
 }
 
 
@@ -410,7 +405,11 @@ Function Enum-HostList {
     foreach($HostItem in $HostList.Split(",")) {
         $HostItem = $HostItem.Trim()
         if(!($HostItem -match $global:IPRegex -or $HostItem.Contains("/"))) {
-            $IPAddress = Get-GetHostByName -Hostname $HostItem
+            try {
+                $IPAddress = Get-GetHostByName -Hostname $HostItem
+            } catch {
+                continue
+            }
             if(Find-InArray -Content $IPAddress -Array $IPAddressList) {
                 ForEach-Object { "127.0.0.1"}
                 continue

--- a/DVS.psm1
+++ b/DVS.psm1
@@ -351,7 +351,12 @@ function Get-GetHostByName {
     if($Hostname -eq $env:COMPUTERNAME) {
         return "127.0.0.1"
     }
-    return [System.Net.Dns]::GetHostByName($Hostname).AddressList[0].IPAddressToString
+    try {
+        return [System.Net.Dns]::GetHostByName($Hostname).AddressList[0].IPAddressToString
+    } catch {
+        Write-Log -Level ERROR -Message "$Hostname $_" -forceVerbose
+        return ""
+    }
 }
 
 
@@ -407,14 +412,14 @@ Function Enum-HostList {
         if(!($HostItem -match $global:IPRegex -or $HostItem.Contains("/"))) {
             $IPAddress = Get-GetHostByName -Hostname $HostItem
             if(Find-InArray -Content $IPAddress -Array $IPAddressList) {
-                % { "127.0.0.1"}
+                ForEach-Object { "127.0.0.1"}
                 continue
             }
-            %{$IPAddress}
+            ForEach-Object{$IPAddress}
             continue
         }
         if(!($HostItem.Contains("/"))) {
-            %{$HostItem}
+            ForEach-Object{$HostItem}
             continue
         }
         $NetworkAddress = ($HostItem.split("/"))[0]
@@ -428,10 +433,10 @@ Function Enum-HostList {
             [Array]::Reverse($IPAddress)
             $IPAddress = ([System.Net.IPAddress]($IPAddress)).IPAddressToString
             if(Find-InArray -Content $IPAddress -Array $IPAddressList) {
-                %{"127.0.0.1"}
+                ForEach-Object{"127.0.0.1"}
                 continue
             }
-            %{$IPAddress}
+            ForEach-Object{$IPAddress}
         }
     }
 }


### PR DESCRIPTION
If a hostname couldn't be resolved the script would crash. Now this is handled.